### PR TITLE
Currently, there seems to be no way to read from a bzip2 or gzip file. Now there is.

### DIFF
--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -96,9 +96,9 @@ Load and validate the header of a pcap file.
         return header
 
 
-def load_savefile(filename, layers=0, verbose=False):
+def load_savefile(input_file, layers=0, verbose=False):
     """
-    Load and parse a savefile as a pcap_savefile instance. Returns the savefile
+    Parse a savefile as a pcap_savefile instance. Returns the savefile
     on success and None on failure. Verbose mode prints additional information
     about the file's processing. layers defines how many layers to descend and
     decode the packet.
@@ -107,13 +107,12 @@ def load_savefile(filename, layers=0, verbose=False):
     old_verbose = VERBOSE
     VERBOSE = verbose
 
-    file_h = open(filename)
-    __TRACE__('[+] attempting to load %s', (filename, ))
+    __TRACE__('[+] attempting to load %s', (input_file.name, ))
 
-    header = _load_savefile_header(file_h)
+    header = _load_savefile_header(input_file)
     if __validate_header__(header):
         __TRACE__('[+] found valid header')
-        packets = _load_packets(file_h, header, layers)
+        packets = _load_packets(input_file, header, layers)
         __TRACE__('[+] loaded %d packets', (len(packets), ))
         sfile = pcap_savefile(header, packets)
         __TRACE__('[+] finished loading savefile.')

--- a/pcapfile/test/linklayer_test.py
+++ b/pcapfile/test/linklayer_test.py
@@ -17,7 +17,7 @@ class TestCase(unittest.TestCase):
     capfile = None
 
     def init_capfile(self, layers=0):
-        self.capfile = savefile.load_savefile('test_data/test.pcap', 
+        self.capfile = savefile.load_savefile(open('test_data/test.pcap', 'r'), 
                                               layers=layers)
 
     @classmethod

--- a/pcapfile/test/savefile_test.py
+++ b/pcapfile/test/savefile_test.py
@@ -27,7 +27,7 @@ class TestCase(unittest.TestCase):
 
     def init_capfile(self, layers=0):
         tfile = create_pcap()
-        self.capfile = savefile.load_savefile(tfile.name, layers=layers)
+        self.capfile = savefile.load_savefile(tfile, layers=layers)
         tfile.close()
         if os.path.exists(tfile.name):
             os.unlink(tfile.name)


### PR DESCRIPTION
This allows bzip2 and gzip files to be used transparently.
