### PR TITLE
Update .travis.yml testing with coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 install: 
   - pip install .
   - pip install codecov
-script:  python -m pcapfile.test
+script: coverage run -m pcapfile.test
 after_success: codecov


### PR DESCRIPTION
You can see the [report here](http://codecov.io/github/kisom/pypcapfile?ref=96e1f61174dcbfab08272abbe6f99bf2cc7cd1c6)

> I'm going to be adding a feature soon that can filter out the `/opt/python/pypy-2.3.1...` files
