### PR TITLE
add function to create generator to iterate over packets, and alterna…

### DIFF
--- a/pcapfile/linklayer.py
+++ b/pcapfile/linklayer.py
@@ -8,6 +8,7 @@ import imp
 import sys
 
 import pcapfile.protocols.linklayer.ethernet as ethernet
+import pcapfile.protocols.network.ip2 as ip2
 
 
 __LL_TYPES__ = [('LINKTYPE_NULL', 0, 'null', None),
@@ -15,7 +16,8 @@ __LL_TYPES__ = [('LINKTYPE_NULL', 0, 'null', None),
                     ethernet.Ethernet),
                 ('LINKTYPE_TOKEN_RING', 6, 'token ring', None),
                 ('LINKTYPE_ARCNET', 7, 'ARCnet', None),
-                ('LINKTYPE_SLIP', 8, 'SLIP', None)]
+                ('LINKTYPE_SLIP', 8, 'SLIP', None),
+                ('LINKTYPE_RAW', 101, 'RAW', ip2.IP)]
 
 
 def __get_ll_type__(ll_type):

--- a/pcapfile/protocols/network/ip2.py
+++ b/pcapfile/protocols/network/ip2.py
@@ -1,0 +1,23 @@
+"""
+IP protocol definitions.
+"""
+
+import ctypes
+
+class IP(ctypes.BigEndianStructure):
+    """
+    Represents an IP header.
+    """
+
+    _fields_ = [('version', ctypes.c_uint8, 4),
+                ('ihl', ctypes.c_uint8, 4),
+                ('tos', ctypes.c_uint8),
+                ('len', ctypes.c_uint16),
+                ('id', ctypes.c_uint16),
+                ('flags', ctypes.c_uint16, 3),
+                ('off', ctypes.c_uint16, 13),
+                ('ttl', ctypes.c_uint8),
+                ('p', ctypes.c_uint8),
+                ('sum', ctypes.c_uint16),
+                ('src', ctypes.c_uint32),
+                ('dst', ctypes.c_uint32)]


### PR DESCRIPTION
These are very early stage changes so I don't expect this pull request to be accepted, but I would appreciate your feedback on the ideas behind the changes.

The first change is to add a generator for iterating over the packets in a savefile. That prevents loading large pcaps into memory.

The second change is an alternate way of decoding higher-layer headers, by casting the raw_packet_data to a ctypes.Struct and avoiding the struct.unpack.

If you're interested in these changes, I'll keep working on them.

Thanks,
Joe