### PR TITLE
Support for nanosecond time resolution.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,5 +4,6 @@
         - load savefile from a Python File object
 - Christian Wenk (https://github.com/chrwen-omicron)
         - improve handling of different endianness
+        - added support for nanosecond time resolution
 - Douglas Kastle (https://github.com/douglaskastle)
         - Added initial python3 support

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ The core functionality is implemented in ``pcapfile.savefile``:
     [+] finished loading savefile.
     >>> print capfile
     little-endian capture file version 2.4
+    microsecond time resolution
     snapshot length: 65535
     linklayer type: LINKTYPE_ETHERNET
     number of packets: 11

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -76,7 +76,7 @@ class pcap_savefile(object):
 
 def _load_savefile_header(file_h):
     """
-Load and validate the header of a pcap file.
+    Load and validate the header of a pcap file.
     """
     try:
         raw_savefile_header = file_h.read(24)
@@ -178,10 +178,7 @@ def _read_a_packet(file_h, hdrp, layers=0):
     per-packet header.
     """
     raw_packet_header = file_h.read(16)
-    if raw_packet_header == '':
-        return None
-    #assert len(raw_packet_header) == 16, 'Unexpected end of per-packet header.'
-    if len(raw_packet_header) != 16:
+    if not raw_packet_header or len(raw_packet_header) != 16:
         return None
 
     # in case the capture file is not the same endianness as ours, we have to
@@ -193,8 +190,7 @@ def _read_a_packet(file_h, hdrp, layers=0):
     (timestamp, timestamp_ms, capture_len, packet_len) = packet_header
     raw_packet_data = file_h.read(capture_len)
 
-    #assert len(raw_packet_data) == capture_len, 'Unexpected end of packet.'
-    if len(raw_packet_data) != capture_len or len(raw_packet_data) == 0:
+    if not raw_packet_data or len(raw_packet_data) != capture_len:
         return None
 
     if layers > 0:

--- a/pcapfile/structs.py
+++ b/pcapfile/structs.py
@@ -8,8 +8,8 @@ import ctypes
 
 class __pcap_header__(ctypes.Structure):
     """
-C-struct representation of a savefile header. See __validate_header__
-for validation.
+    C-struct representation of a savefile header. See __validate_header__
+    for validation.
     """
     _fields_ = [('magic', ctypes.c_uint),        # file magic number
                 ('major', ctypes.c_ushort),      # major version number

--- a/pcapfile/structs.py
+++ b/pcapfile/structs.py
@@ -11,14 +11,15 @@ class __pcap_header__(ctypes.Structure):
     C-struct representation of a savefile header. See __validate_header__
     for validation.
     """
-    _fields_ = [('magic', ctypes.c_uint),        # file magic number
-                ('major', ctypes.c_ushort),      # major version number
-                ('minor', ctypes.c_ushort),      # minor version number
-                ('tz_off', ctypes.c_uint),       # timezone offset
-                ('ts_acc', ctypes.c_uint),       # timestamp accuracy
-                ('snaplen', ctypes.c_uint),      # snapshot length
-                ('ll_type', ctypes.c_uint),      # link layer header type
-                ('byteorder', ctypes.c_char_p)]  # byte order specifier
+    _fields_ = [('magic', ctypes.c_uint),          # file magic number
+                ('major', ctypes.c_ushort),        # major version number
+                ('minor', ctypes.c_ushort),        # minor version number
+                ('tz_off', ctypes.c_uint),         # timezone offset
+                ('ts_acc', ctypes.c_uint),         # timestamp accuracy
+                ('snaplen', ctypes.c_uint),        # snapshot length
+                ('ll_type', ctypes.c_uint),        # link layer header type
+                ('byteorder', ctypes.c_char_p),    # byte order specifier
+                ('ns_resolution', ctypes.c_bool)]  # nanosecond resolution
 
 
 class pcap_packet(ctypes.Structure):


### PR DESCRIPTION
Now the magic number for nanosecond time resolution pcap files is accepted as well. I also added an attribute to the header which indicates if the timestamp_ms is given in nanoseconds or microseconds.