### PR TITLE
Create specific Exceptions for the module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@
 - Marco 'don' Kaulea (https://github.com/Don42)
         - fixed error in setup.py
         - rename misnamed variable
+        - introduce custom exceptions

--- a/pcapfile/__init__.py
+++ b/pcapfile/__init__.py
@@ -1,0 +1,16 @@
+
+class Error(Exception):
+    pass
+
+
+class InvalidEncoding(Error):
+    pass
+
+
+class UnknownMagicNumber(Error):
+    pass
+
+
+class InvalidHeader(Error):
+    pass
+

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -11,8 +11,8 @@ import struct
 import sys
 
 import pcapfile.linklayer as linklayer
-
 from pcapfile.structs import __pcap_header__, pcap_packet
+from pcapfile import InvalidEncoding, UnknownMagicNumber, InvalidHeader
 
 VERBOSE = False
 
@@ -89,7 +89,7 @@ def _load_savefile_header(file_h):
         raw_savefile_header = file_h.read(24)
     except UnicodeDecodeError:
         print("\nMake sure the input file is opened in read binary, 'rb'\n")
-        raise
+        raise InvalidEncoding("Could not read file. Might not be opened as binary.")
 
     # in case the capture file is not the same endianness as ours, we have to
     # use the correct byte order for the file header
@@ -102,14 +102,14 @@ def _load_savefile_header(file_h):
         byte_order = b'little'
         unpacked = struct.unpack('<IhhIIII', raw_savefile_header)
     else:
-        raise Exception('Invalid pcap file.')
+        raise UnknownMagicNumber("No supported Magic Number found")
 
     (magic, major, minor, tz_off, ts_acc, snaplen, ll_type) = unpacked
     header = __pcap_header__(magic, major, minor, tz_off, ts_acc, snaplen,
                              ll_type, ctypes.c_char_p(byte_order),
                              magic == _MAGIC_NUMBER_NS)
     if not __validate_header__(header):
-        raise Exception('invalid savefile header!')
+        raise InvalidHeader("Invalid Header")
     else:
         return header
 

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -89,7 +89,7 @@ def _load_savefile_header(file_h):
         raw_savefile_header = file_h.read(24)
     except UnicodeDecodeError:
         print("\nMake sure the input file is opened in read binary, 'rb'\n")
-        raise InvalidEncoding("Could not read file. Might not be opened as binary.")
+        raise InvalidEncoding("Could not read file; it might not be opened in binary mode.")
 
     # in case the capture file is not the same endianness as ours, we have to
     # use the correct byte order for the file header


### PR DESCRIPTION
This allows the user of the library to specifically catch all Exceptions
from this module by catching the base error defined in the module.

Closes #18 