### PR TITLE
Rename timestamp_ms to timestamp_us

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@
         - added support for large captures
 - Marco 'don' Kaulea (https://github.com/Don42)
         - fixed error in setup.py
+        - rename misnamed variable

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -215,7 +215,7 @@ def _read_a_packet(file_h, hdrp, layers=0):
         packet_header = struct.unpack('>IIII', raw_packet_header)
     else:
         packet_header = struct.unpack('<IIII', raw_packet_header)
-    (timestamp, timestamp_ms, capture_len, packet_len) = packet_header
+    (timestamp, timestamp_us, capture_len, packet_len) = packet_header
     raw_packet_data = file_h.read(capture_len)
 
     if not raw_packet_data or len(raw_packet_data) != capture_len:
@@ -228,6 +228,6 @@ def _read_a_packet(file_h, hdrp, layers=0):
     else:
         raw_packet = binascii.hexlify(raw_packet_data)
 
-    packet = pcap_packet(hdrp, timestamp, timestamp_ms, capture_len,
+    packet = pcap_packet(hdrp, timestamp, timestamp_us, capture_len,
                          packet_len, raw_packet)
     return packet

--- a/pcapfile/structs.py
+++ b/pcapfile/structs.py
@@ -32,18 +32,18 @@ class pcap_packet(ctypes.Structure):
     """
     _fields_ = [('header', ctypes.POINTER(__pcap_header__)),
                 ('timestamp', ctypes.c_uint),
-                ('timestamp_ms', ctypes.c_uint),
+                ('timestamp_us', ctypes.c_uint),
                 ('capture_len', ctypes.c_uint),
                 ('packet_len', ctypes.c_uint)]
 
     packet = None
 
-    def __init__(self, header, timestamp, timestamp_ms, capture_len,
+    def __init__(self, header, timestamp, timestamp_us, capture_len,
                  packet_len, packet):
         super(pcap_packet, self).__init__()
         self.header = header
         self.timestamp = timestamp
-        self.timestamp_ms = timestamp_ms
+        self.timestamp_us = timestamp_us
         self.capture_len = capture_len
         self.packet_len = packet_len
         self.packet = packet
@@ -62,3 +62,7 @@ class pcap_packet(ctypes.Structure):
                 return str(self.packet)
         else:
             return str(self.packet)
+
+    @property
+    def timestamp_ms(self):
+        return self.timestamp_us / 1000

--- a/pcapfile/test/savefile_test.py
+++ b/pcapfile/test/savefile_test.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(int(bytearray(packet)[14]), 69, 'invalid packet')
 
         for packet in self.capfile.packets:
-            for field in ['capture_len', 'timestamp', 'timestamp_ms',
+            for field in ['capture_len', 'timestamp', 'timestamp_us',
                           'packet', 'header', 'packet_len']:
                 self.assertTrue(hasattr(packet, field), 'invalid packet!')
 
@@ -128,7 +128,7 @@ class TestCase(unittest.TestCase):
                          'lazy parsing gives different number of packets!')
 
         # Compare the relevant parts of the packets.
-        fields = ['timestamp', 'timestamp_ms', 'capture_len',
+        fields = ['timestamp', 'timestamp_us', 'capture_len',
                   'packet_len', 'packet']
         for act, ref in zip(packets, capfile_gen.packets):
             for field in fields:


### PR DESCRIPTION
The actually value read from pcap files are in
microseconds, therefore the timestamp has been named wrong.
For users who need the sub-second timestamp in milliseconds a
property has been added to the packet object.

Closes #12 