### PR TITLE
Adding a file length option and documentation to iterate over packets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,6 @@
         - TCP transport support
 - Kivanc Cakmak (https://github.com/kivanccakmak)
         - added Wi-Fi support
+- Shea Lutton (https://github.com/shealutton)
+	- added length of pcap file
+	- added documentation to iterate over all packets

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,19 @@ and this example:
     >>> print capfile.packets[0].packet.payload
     <hex string snipped>
 
+and this example to pull the raw payload from every packet in a pcap file:
+
+.. code:: python
+
+    >>> from pcapfile import savefile
+    >>> import binascii
+
+    >>> capfile = savefile.load_savefile(testcap)
+    >>> file_length = capfile.__length__()
+    >>> for packet in range(0, file_length):
+    >>>     pkt = capfile.packets[packet]
+    >>>     data = binascii.b2a_qp(pkt.raw())  # Do something here
+
 and lastly:
 
 .. code:: python

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -80,6 +80,9 @@ class pcap_savefile(object):
                          linklayer.lookup(self.header.ll_type),
                          len(self.packets))
 
+    def __length__(self):
+        return len(self.packets)
+
 
 def _load_savefile_header(file_h):
     """

--- a/pcapfile/test/savefile_test.py
+++ b/pcapfile/test/savefile_test.py
@@ -106,6 +106,8 @@ class TestCase(unittest.TestCase):
         self.assertTrue(self.capfile.valid, 'invalid capture file')
         self.assertEqual(len(self.capfile.packets), 23,
                          'wrong number of packets!')
+        self.assertEqual(self.capfile.__length__(), 23,
+                         '__length__ not reporting correct number of packets')
 
     def test_lazy_import(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 setup(name='pypcapfile',
-      version='0.12.0',
+      version='0.12.1',
       description=('Pure Python package for reading and parsing libpcap '
                        'savefiles.'),
       long_description=read('README.rst'),


### PR DESCRIPTION
Kisom, thanks for writing this lib. It was really helpful for me, but I needed a way to iterate over 20 million packets and pull raw data out of the payload. I added a length option and some documentation on how to read over every packet to the README. Would you incorporate this into your distribution? Thanks, Shea