### PR TITLE
Some pylint fixes

### DIFF
--- a/pcapfile/__init__.py
+++ b/pcapfile/__init__.py
@@ -13,4 +13,3 @@ class UnknownMagicNumber(Error):
 
 class InvalidHeader(Error):
     pass
-

--- a/pcapfile/linklayer.py
+++ b/pcapfile/linklayer.py
@@ -12,8 +12,7 @@ import pcapfile.protocols.linklayer.wifi as wifi
 
 
 __LL_TYPES__ = [('LINKTYPE_NULL', 0, 'null', None),
-                ('LINKTYPE_ETHERNET', 1, 'ethernet',
-                    ethernet.Ethernet),
+                ('LINKTYPE_ETHERNET', 1, 'ethernet', ethernet.Ethernet),
                 ('LINKTYPE_IEEE802_11_RADIOTAP', 127, wifi.Wifi),
                 ('LINKTYPE_TOKEN_RING', 6, 'token ring', None),
                 ('LINKTYPE_ARCNET', 7, 'ARCnet', None),

--- a/pcapfile/protocols/linklayer/ethernet.py
+++ b/pcapfile/protocols/linklayer/ethernet.py
@@ -19,6 +19,7 @@ class Ethernet(ctypes.Structure):
     payload = None
 
     def __init__(self, packet, layers=0):
+        super(Ethernet, self).__init__()
         (dst, src, self.type) = struct.unpack('!6s6sH', packet[:14])
 
         dst = bytearray(dst)
@@ -60,11 +61,11 @@ def strip_ethernet(packet):
     """
     Strip the Ethernet frame from a packet.
     """
-    if not type(packet) == Ethernet:
+    if not isinstance(packet, Ethernet):
         packet = Ethernet(packet)
     payload = packet.payload
 
-    if type(payload) == str:
+    if isinstance(payload, str):
         payload = binascii.unhexlify(payload)
     return payload
 

--- a/pcapfile/protocols/transport/tcp.py
+++ b/pcapfile/protocols/transport/tcp.py
@@ -6,36 +6,38 @@ import binascii
 import ctypes
 import struct
 
+
 class TCP(ctypes.Structure):
     """
     Represents a TCP packet
     """
 
-    _fields_ = [('src_port', ctypes.c_ushort),  # source port
-                ('dst_port', ctypes.c_ushort),  # destination port
-                ('seqnum', ctypes.c_uint),      # sequence number
-                ('acknum', ctypes.c_uint),      # acknowledgment number
-                ('data_offset', ctypes.c_uint), # data offset in bytes
-                ('urg', ctypes.c_bool),         # URG
-                ('ack', ctypes.c_bool),         # ACK
-                ('psh', ctypes.c_bool),         # PSH
-                ('rst', ctypes.c_bool),         # RST
-                ('syn', ctypes.c_bool),         # SYN
-                ('fin', ctypes.c_bool),         # FIN
-                ('win', ctypes.c_ushort),       # window size
-                ('sum', ctypes.c_ushort),       # checksum
-                ('opt', ctypes.c_char_p),       # options
-                ('payload', ctypes.c_char_p)]   # packet payload
+    _fields_ = [('src_port', ctypes.c_ushort),   # source port
+                ('dst_port', ctypes.c_ushort),   # destination port
+                ('seqnum', ctypes.c_uint),       # sequence number
+                ('acknum', ctypes.c_uint),       # acknowledgment number
+                ('data_offset', ctypes.c_uint),  # data offset in bytes
+                ('urg', ctypes.c_bool),          # URG
+                ('ack', ctypes.c_bool),          # ACK
+                ('psh', ctypes.c_bool),          # PSH
+                ('rst', ctypes.c_bool),          # RST
+                ('syn', ctypes.c_bool),          # SYN
+                ('fin', ctypes.c_bool),          # FIN
+                ('win', ctypes.c_ushort),        # window size
+                ('sum', ctypes.c_ushort),        # checksum
+                ('opt', ctypes.c_char_p),        # options
+                ('payload', ctypes.c_char_p)]    # packet payload
 
     tcp_min_header_size = 20
 
     def __init__(self, packet, layers=0):
+        super(TCP, self).__init__()
         fields = struct.unpack("!HHIIBBHHH", packet[:self.tcp_min_header_size])
         self.src_port = fields[0]
         self.dst_port = fields[1]
         self.seqnum = fields[2]
         self.acknum = fields[3]
-        
+
         self.data_offset = 4 * (fields[4] >> 4)
 
         self.urg = fields[5] & 32
@@ -47,7 +49,7 @@ class TCP(ctypes.Structure):
 
         self.win = fields[6]
         self.sum = fields[7]
-        urg_offset = 4 * fields[8] # rarely used
+        # urg_offset = 4 * fields[8]  # rarely used
 
         if self.data_offset < 20:
             self.opt = b''
@@ -59,14 +61,18 @@ class TCP(ctypes.Structure):
     def __str__(self):
         packet = 'tcp %s packet from port %d to port %d carrying %d bytes'
         str_flags = ''
-        if self.syn: str_flags += 'S'
-        if self.ack: str_flags += 'A'
-        if self.rst: str_flags += 'R'
-        if self.fin: str_flags += 'F'
-        if self.urg: str_flags += 'U'
+        if self.syn:
+            str_flags += 'S'
+        if self.ack:
+            str_flags += 'A'
+        if self.rst:
+            str_flags += 'R'
+        if self.fin:
+            str_flags += 'F'
+        if self.urg:
+            str_flags += 'U'
         packet = packet % (str_flags, self.src_port, self.dst_port, (len(self.payload) // 2))
         return packet
 
     def __len__(self):
         return max(self.data_offset, self.tcp_min_header_size) + len(self.payload) // 2
-

--- a/pcapfile/protocols/transport/udp.py
+++ b/pcapfile/protocols/transport/udp.py
@@ -6,6 +6,7 @@ import binascii
 import ctypes
 import struct
 
+
 class UDP(ctypes.Structure):
     """
     Represents a UDP packet
@@ -20,6 +21,7 @@ class UDP(ctypes.Structure):
     udp_header_size = 8
 
     def __init__(self, packet, layers=0):
+        super(UDP, self).__init__()
         fields = struct.unpack("!HHHH", packet[:self.udp_header_size])
         self.src_port = fields[0]
         self.dst_port = fields[1]
@@ -34,4 +36,3 @@ class UDP(ctypes.Structure):
 
     def __len__(self):
         return self.udp_header_size + len(self.payload)
-

--- a/pcapfile/savefile.py
+++ b/pcapfile/savefile.py
@@ -28,6 +28,13 @@ def __TRACE__(msg, args=None):
             print(msg)
 
 
+def validate_packet(pkt):
+    # TODO: extended validation
+    if pkt is None:
+        return False
+    return True
+
+
 class pcap_savefile(object):
     """
     Represents a libpcap savefile. The packets member is a list of pcap_packet
@@ -57,11 +64,8 @@ class pcap_savefile(object):
 
         # Validate the packets unless they are to be loaded lazily.
         if isinstance(self.packets, list):
-            # TODO: extended validation
-            valid_packet = lambda pkt: (pkt is not None or
-                                        pkt.issubclass(ctypes.Structure))
-            if not 0 == len(self.packets):
-                valid_packet = [valid_packet(pkt) for pkt in self.packets]
+            if len(self.packets):
+                valid_packet = [validate_packet(pkt) for pkt in self.packets]
                 assert False not in valid_packet, 'Invalid packets in savefile.'
                 if False in valid_packet:
                     return False
@@ -150,7 +154,7 @@ def load_savefile(input_file, layers=0, verbose=False, lazy=False):
 
 
 def __validate_header__(header):
-    if not type(header) == __pcap_header__:
+    if not isinstance(header, __pcap_header__):
         return False
 
     if header.magic not in [_MAGIC_NUMBER, _MAGIC_NUMBER_NS]:

--- a/pcapfile/test/__main__.py
+++ b/pcapfile/test/__main__.py
@@ -13,8 +13,7 @@ from pcapfile.test.protocols_linklayer_wifi import TestCase as WifiTest
 from pcapfile.test.protocols_transport_tcp import TestCase as TcpTest
 
 if __name__ == '__main__':
-    TEST_CLASSES = [SavefileTest, LinklayerTest, EthernetTest, WifiTest,
-            TcpTest]
+    TEST_CLASSES = [SavefileTest, LinklayerTest, EthernetTest, WifiTest, TcpTest]
     SUITE = unittest.TestSuite()
     LOADER = unittest.TestLoader()
     for test_class in TEST_CLASSES:

--- a/pcapfile/test/protocols_linklayer_wifi.py
+++ b/pcapfile/test/protocols_linklayer_wifi.py
@@ -8,7 +8,7 @@ import unittest
 
 from pcapfile.protocols.linklayer import wifi
 
-#partial data packet, unnecessary tailing payload removed
+# partial data packet, unnecessary tailing payload removed
 DATA_NON_AMSDU_WDS_PACKET = [b'000026002b4820002364e679000000004000a415400',
                              b'1b30000004400040474000000000000008803480088',
                              b'41d82a01aa8841fc7a0fd3a08614180220387400020',
@@ -40,7 +40,7 @@ DATA_NON_AMSDU_WDS_PACKET = [b'000026002b4820002364e679000000004000a415400',
                              b'3435363738393031323334353637383930313233343',
                              b'53e3738393031323334356437383930313233343532']
 
-#entire data packet, all payload included to check number of msdu's in a-msdu
+# entire data packet, all payload included to check number of msdu's in a-msdu
 DATA_AMSDU_WDS_PACKET = [b'000026002b4820002a80a778000000000000a4154001e100',
                          b'0000440004045300000000000000880348008841fc2a01a6',
                          b'8841fc2a01aa00000000000050020000000000008000b8ae',
@@ -67,7 +67,7 @@ DATA_AMSDU_WDS_PACKET = [b'000026002b4820002a80a778000000000000a4154001e100',
                          b'c4cc40004006ef13c0a802cac0a802c91389d3e380ceb976',
                          b'b6141ba1801049883a9600000101080a00f47d890279f75c']
 
-#entire probe request packet
+# entire probe request packet
 PROBE_REQUEST = [b'00001a002f48000092706a4800000000000c3c144001df0000004008',
                  b'3c008841fc1f99d28841fc5721128841fc57211280f200086f736d61',
                  b'6e63616e01080c1218243048606cdd0b001ca8500102572112e03a2d',
@@ -78,7 +78,7 @@ PROBE_REQUEST = [b'00001a002f48000092706a4800000000000c3c144001df0000004008',
                  b'1e00904c33ad0917ffffff0000000000000000000000000000000000',
                  b'000000dd070050f208001400']
 
-#entire probe response packet
+# entire probe response packet
 PROBE_RESPONSE = [b'00001a002f4800001f4d634800000000000c3c144001d3000000500',
                   b'83c008086f281daa8c03e0f5ce558c03e0f5ce55820b91653d01804',
                   b'000000640011110011536576656e4e6f6465732d3530472d3336010',
@@ -99,7 +99,7 @@ PROBE_RESPONSE = [b'00001a002f4800001f4d634800000000000c3c144001d3000000500',
                   b'0001c0000dd180050f2020101840003a4000027a4000042435e0062',
                   b'322f0046057200010000']
 
-#entire beacon packet
+# entire beacon packet
 BEACON_PACKET = [b'00001a002f48000054446f7800000000000ca4154001e80000008000',
                  b'0000ffffffffffff8841fc2a01aa8841fc2a01aa101f0a70a81e0000',
                  b'0000640001050014416972546965735f416972343832305f30314139',
@@ -119,15 +119,15 @@ BEACON_PACKET = [b'00001a002f48000054446f7800000000000ca4154001e80000008000',
                  b'22007fc5100018373732383835383433393337353535333338383739',
                  b'32386630000101']
 
-#entire rts packet
+# entire rts packet
 RTS_PACKET = [b'00001a002f4800008334e27800000000000ca4154001df000000b400340',
               b'b8841fc2a01aa8841fc2a01a6']
 
-#entire cts packet
+# entire cts packet
 CTS_PACKET = [b'00001a002f480000c634e27800000000000ca4154001e7000000c400f80',
               b'a8841fc2a01a6']
 
-#entire block ack packet
+# entire block ack packet
 BLOCK_ACK_PACKET = [b'00001a002f480000b23fe278000000000030a415400',
                     b'1e8000000940000008841fc2a01a68841fc2a01aa05',
                     b'00902cffffffffff010000']
@@ -140,6 +140,7 @@ CTS_PACKET = binascii.unhexlify(b''.join(CTS_PACKET))
 BLOCK_ACK_PACKET = binascii.unhexlify(b''.join(BLOCK_ACK_PACKET))
 DATA_AMSDU_WDS_PACKET = binascii.unhexlify(b''.join(DATA_AMSDU_WDS_PACKET))
 DATA_NON_AMSDU_WDS_PACKET = binascii.unhexlify(b''.join(DATA_NON_AMSDU_WDS_PACKET))
+
 
 class TestCase(unittest.TestCase):
     """
@@ -161,17 +162,17 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.RTS),
                         'invalid RTS frame!')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.radiotap.mactime, 2028090499,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.rate, 6.0,
-                'invalid rate')
+                         'invalid rate')
         self.assertEqual(frame.ta, b'88:41:fc:2a:01:a6',
-                'invalid transmitter address')
+                         'invalid transmitter address')
         self.assertEqual(frame.ra, b'88:41:fc:2a:01:aa',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.duration, 2868,
-                'invalid duration field')
+                         'invalid duration field')
 
     def test_cts_packet(self):
         """
@@ -181,15 +182,15 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.CTS),
                         'invalid CTS frame!')
         self.assertEqual(frame.radiotap.mactime, 2028090566,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.radiotap.rate, 6.0,
-                'invalid rate')
+                         'invalid rate')
         self.assertEqual(frame.ra, b'88:41:fc:2a:01:a6',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.duration, 2808,
-                'invalid duration field')
+                         'invalid duration field')
 
     def test_block_ack_packet(self):
         """
@@ -199,15 +200,15 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.BACK),
                         'invalid BLOCK ACK frame!')
         self.assertEqual(frame.radiotap.mactime, 2028093362,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.ta, b'88:41:fc:2a:01:aa',
-                'invalid transmitter address')
+                         'invalid transmitter address')
         self.assertEqual(frame.ra, b'88:41:fc:2a:01:a6',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.acked_seqs, list(range(713, 754)),
-                'invalid sequence numbers in acknowledgement') 
+                         'invalid sequence numbers in acknowledgement')
 
     def test_beacon_packet(self):
         """
@@ -217,17 +218,17 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.Beacon),
                         'invalid Beacon frame!')
         self.assertEqual(frame.radiotap.mactime, 2020557908,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.ta, b'88:41:fc:2a:01:aa',
-                'invalid transmitter address')
+                         'invalid transmitter address')
         self.assertEqual(frame.ra, b'ff:ff:ff:ff:ff:ff',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.timestamp, 514355210,
-                'invalid beacon timestamp')
+                         'invalid beacon timestamp')
         self.assertEqual(frame.seq_num, 497,
-                'invalid sequence number')
+                         'invalid sequence number')
 
     def test_probe_req_packet(self):
         """
@@ -237,13 +238,13 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.ProbeReq),
                         'invalid Beacon frame!')
         self.assertEqual(len(frame.tagged_params), 10,
-                'invalid number of tagged paramters')
+                         'invalid number of tagged paramters')
         vendor_ies = frame.get_vendor_ies()
         self.assertEqual(len(vendor_ies), 5,
-                'invalid number of vendor ies')
+                         'invalid number of vendor ies')
         ie_type = frame.get_vendor_ies('00-1C-A8', 80)
         self.assertEqual(len(ie_type), 1,
-            'invalid number of ies for mac block 00-1C-A8')
+                         'invalid number of ies for mac block 00-1C-A8')
 
     def test_probe_resp_packet(self):
         """
@@ -251,41 +252,41 @@ class TestCase(unittest.TestCase):
         """
         frame = wifi.WIFI(PROBE_RESP_PACKET)
         self.assertTrue(isinstance(frame, wifi.ProbeResp),
-                'invalid Probe Response frame!')
+                        'invalid Probe Response frame!')
         self.assertEqual(frame.timestamp, 17596175126,
-                'invalid timestamp')
+                         'invalid timestamp')
         self.assertEqual(frame.ess, 1,
-                'invalid ess flag')
+                         'invalid ess flag')
         self.assertEqual(frame.ibss, 0,
-                'invalid ibss flag')
+                         'invalid ibss flag')
         self.assertEqual(frame.priv, 1,
-                'invalid privacy capability flag')
+                         'invalid privacy capability flag')
         self.assertEqual(frame.short_preamble, 0,
-                'invalid short preamble flag')
+                         'invalid short preamble flag')
         self.assertEqual(frame.pbcc, 0,
-                'invalid pbcc flag')
+                         'invalid pbcc flag')
         self.assertEqual(frame.chan_agility, 0,
-                'invalid channel agility flag')
+                         'invalid channel agility flag')
         self.assertEqual(frame.spec_man, 1,
-                'invalid spectrum management flag')
+                         'invalid spectrum management flag')
         self.assertEqual(frame.short_slot, 0,
-                'invalid short slot time flag')
+                         'invalid short slot time flag')
         self.assertEqual(frame.apsd, 0,
-                'invalid automatic power save delivery flag')
+                         'invalid automatic power save delivery flag')
         self.assertEqual(frame.dss_ofdm, 0,
-                'invalid dynamic spec spectrum / ofdm flag')
+                         'invalid dynamic spec spectrum / ofdm flag')
         self.assertEqual(frame.del_back, 0,
-                'invalid delayed block ack flag')
+                         'invalid delayed block ack flag')
         self.assertEqual(frame.imm_back, 0,
-                'invalid immediate block ack flag')
+                         'invalid immediate block ack flag')
         self.assertEqual(len(frame.tagged_params), 18,
-                'invalid number of tagged parameters')
+                         'invalid number of tagged parameters')
         vendor_ies = frame.get_vendor_ies()
         self.assertEqual(len(vendor_ies), 4,
-                'invalid number of vendor ies')
+                         'invalid number of vendor ies')
         ie_type = frame.get_vendor_ies('00-10-18', 2)
         self.assertEqual(len(ie_type), 1,
-                'invalid number of ies for mac block 00-10-18')
+                         'invalid number of ies for mac block 00-10-18')
 
     def test_data_amsdu_wds_packet(self):
         """
@@ -296,23 +297,23 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.QosData),
                         'invalid QosData frame!')
         self.assertEqual(frame.radiotap.mactime, 2024243242,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.from_ds, 1,
-                'invalid flag value in frame control')
+                         'invalid flag value in frame control')
         self.assertEqual(frame.to_ds, 1,
-                'invalid flag value in frame control')
+                         'invalid flag value in frame control')
         self.assertEqual(frame.amsdupresent, 1,
-                'invalid a-msdu information')
+                         'invalid a-msdu information')
         self.assertEqual(frame.ta, b'88:41:fc:2a:01:aa',
-                'invalid transmitter address')
+                         'invalid transmitter address')
         self.assertEqual(frame.ra, b'88:41:fc:2a:01:a6',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.seq_num, 37,
-                'invalid sequence number')
+                         'invalid sequence number')
         self.assertEqual(len(frame.payload), 7,
-                'invalid a-msdu aggregation formed')
+                         'invalid a-msdu aggregation formed')
 
     def test_data_non_amsdu_wds_packet(self):
         """
@@ -323,20 +324,20 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(frame, wifi.QosData),
                         'invalid QosData frame!')
         self.assertEqual(frame.radiotap.mactime, 2045142051,
-                'invalid radiotap mactime')
+                         'invalid radiotap mactime')
         self.assertEqual(frame.radiotap.chan.freq, 5540,
-                'invalid channel frequency in radiotap headers')
+                         'invalid channel frequency in radiotap headers')
         self.assertEqual(frame.from_ds, 1,
-                'invalid flag value in frame control')
+                         'invalid flag value in frame control')
         self.assertEqual(frame.to_ds, 1,
-                'invalid flag value in frame control')
+                         'invalid flag value in frame control')
         self.assertEqual(frame.amsdupresent, 0,
-                'invalid a-msdu information')
+                         'invalid a-msdu information')
         self.assertEqual(frame.ta, b'88:41:fc:7a:0f:d3',
-                'invalid transmitter address')
+                         'invalid transmitter address')
         self.assertEqual(frame.ra, b'88:41:d8:2a:01:aa',
-                'invalid receiver address')
+                         'invalid receiver address')
         self.assertEqual(frame.seq_num, 1859,
-                'invalid sequence number')
+                         'invalid sequence number')
         self.assertEqual(len(frame.payload), 1,
-                'invalid a-msdu aggregation formed')
+                         'invalid a-msdu aggregation formed')

--- a/pcapfile/test/protocols_transport_tcp.py
+++ b/pcapfile/test/protocols_transport_tcp.py
@@ -7,11 +7,10 @@ import binascii
 import unittest
 
 from pcapfile import savefile
-from pcapfile.protocols.linklayer import ethernet
 from pcapfile.protocols.network.ip import IP
 from pcapfile.protocols.transport.tcp import TCP
 
-TEST_PAYLOAD=b'''\
+TEST_PAYLOAD = b'''\
 GET /?q=1 HTTP/1.1\r
 Host: 192.168.54.1:8080\r
 User-Agent: curl/7.43.0\r
@@ -32,8 +31,8 @@ class TestCase(unittest.TestCase):
         frame = pcap_packet.packet
         packet = frame.payload
         segment = packet.payload
-        
-        for k,v in kwargs.items():
+
+        for k, v in kwargs.items():
             if hasattr(segment, k):
                 self.assertEqual(getattr(segment, k), v, k)
             elif hasattr(packet, k):
@@ -47,27 +46,26 @@ class TestCase(unittest.TestCase):
         with open('pcapfile/test/test_data/http_conversation.pcap', 'rb') as f:
             self.packets = savefile.load_savefile(f, layers=3).packets
 
-
     def test_basic_parsing(self):
         for pcap_packet in self.packets:
             frame = pcap_packet.packet
             packet = frame.payload
             self.assertTrue(isinstance(packet, IP))
-            
+
             segment = packet.payload
             self.assertTrue(isinstance(segment, TCP))
 
     def test_extensive(self):
         self.assertTcp(self.packets[0], syn=True, ack=False, fin=False,
-            rst=False, psh=False, seqnum=223930318, win=29200, sum=0xd2f6)
+                       rst=False, psh=False, seqnum=223930318, win=29200, sum=0xd2f6)
         self.assertTcp(self.packets[1], syn=True, ack=True, sum=0x18e3)
 
         self.assertTcp(self.packets[3], syn=False, ack=True, psh=True,
-                payload=binascii.hexlify(TEST_PAYLOAD))
+                       payload=binascii.hexlify(TEST_PAYLOAD))
 
     def test_payload(self):
         self.assertTcp(self.packets[3], syn=False, ack=True, psh=True,
-                payload=binascii.hexlify(TEST_PAYLOAD))
+                       payload=binascii.hexlify(TEST_PAYLOAD))
 
     def test_empty_payload(self):
         self.assertTcp(self.packets[0], payload=b'')

--- a/setup.py
+++ b/setup.py
@@ -3,31 +3,34 @@
 import os
 from distutils.core import setup
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-setup(name='pypcapfile',
-      version='0.12.1',
-      description=('Pure Python package for reading and parsing libpcap '
-                       'savefiles.'),
-      long_description=read('README.rst'),
-      author='Kyle Isom',
-      author_email='coder@kyleisom.net',
-      license='ISC',
-      url='http://kisom.github.com/pypcapfile',
-      scripts=['pcapfile_info',],
-      packages=['pcapfile',
-                'pcapfile.test',
-                'pcapfile.protocols',
-                'pcapfile.protocols.linklayer',
-                'pcapfile.protocols.network',
-                'pcapfile.protocols.transport',
-                ],
-      package_data={'pcapfile.test': ['test/test_data']},
-      data_files=[('share/doc/pcapfile',
-                   ['README.rst', 'AUTHORS', 'CONTRIBUTING'])],
-      classifiers=[
+setup(
+    name='pypcapfile',
+    version='0.12.1',
+    description='Pure Python package for reading and parsing libpcap savefiles',
+    long_description=read('README.rst'),
+    author='Kyle Isom',
+    author_email='coder@kyleisom.net',
+    license='ISC',
+    url='https://kisom.github.com/pypcapfile',
+    scripts=['pcapfile_info'],
+    packages=[
+        'pcapfile',
+        'pcapfile.test',
+        'pcapfile.protocols',
+        'pcapfile.protocols.linklayer',
+        'pcapfile.protocols.network',
+        'pcapfile.protocols.transport',
+    ],
+    package_data={'pcapfile.test': ['test/test_data']},
+    data_files=[
+        ('share/doc/pcapfile', ['README.rst', 'AUTHORS', 'CONTRIBUTING'])
+    ],
+    classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
@@ -35,6 +38,5 @@ setup(name='pypcapfile',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        ],
-      )
-
+    ],
+)


### PR DESCRIPTION
- PEP8 fixes
- Remove unused imports
- Remove unused variables
- Fix bare except:
- Fix comparison to None
- Fix misplaced comparison constant "0 == len(self.packets)"
- Use isinstance() for typecheck instead of type()
- Fix "__init__ method from base class 'Structure' is not called"
- Do not assign a lambda expression, use a def (also fix "'pcap_packet'
  object has no attribute 'issubclass'")
- Use logging.warning() instead of the deprecated logging.warn()